### PR TITLE
Remove SFDX_CONSUMER_KEY from scratch org creation

### DIFF
--- a/scripts/deployment/createNewScratchOrg.sh
+++ b/scripts/deployment/createNewScratchOrg.sh
@@ -8,7 +8,7 @@ if [ ! -f "$CREDFILE" ]; then
   
   echo "Creating Org"
   echo "------------"
-  sfdx force:org:create --setalias "$ALIAS" --clientid="$SFDX_CONSUMER_KEY" --definitionfile ./config/project-scratch-def.json --durationdays 1
+  sfdx force:org:create --setalias "$ALIAS" --definitionfile ./config/project-scratch-def.json --durationdays 1
   sfdx force:org:display --targetusername "$ALIAS" --verbose > "$CREDFILE"
   echo ""
 else


### PR DESCRIPTION
This will probably cause trouble when re-authenticating with the new scratch org